### PR TITLE
Address the sticky-ymlfront-metadata problem.

### DIFF
--- a/IkiWiki/Plugin/ymlfront.pm
+++ b/IkiWiki/Plugin/ymlfront.pm
@@ -45,6 +45,7 @@ use IkiWiki 3.00;
 sub import {
 	hook(type => "getsetup", id => "ymlfront", call => \&getsetup);
 	hook(type => "checkconfig", id => "ymlfront", call => \&checkconfig);
+	hook(type => "needsbuild", id => "ymlfront", call => \&needsbuild);
 	hook(type => "filter", id => "ymlfront", call => \&filter, first=>1);
 	hook(type => "preprocess", id => "ymlfront", call => \&preprocess, scan=>1);
 	hook(type => "scan", id => "ymlfront", call => \&scan);
@@ -101,6 +102,24 @@ sub checkconfig () {
 	$config{ymlfront_set_content} = 0;
     }
 } # checkconfig
+
+# Without this, pages get refreshed with one-refresh-old values of their
+# metadata, found in %pagestate. Or perhaps that only happens for a certain
+# order of scanning pages - but that's not defined or predictable. Also
+# without this, a deleted metadata field never disappears until a rebuild.
+sub needsbuild() {
+	my $chgd = shift;
+	my $deld = shift;
+	for my $fns ( $chgd, $deld ) {
+		for my $fn ( @$fns ) {
+			my $type = pagetype($fn);
+			next unless defined $type;
+			my $page = pagename($fn);
+			undef %{$pagestate{$page}{ymlfront}};
+		}
+	}
+	return;
+}
 
 sub scan (@) {
     my %params=@_;


### PR DESCRIPTION
Addresses issue #4, except for previews.

If, in editing, an element is deleted from the YAML metadata, nothing was
removing it from %pagestate, so it would never disappear until a full rebuild.

More subtly, even a changed metadata value might not be reflected in pages
that refer to it until one additional refresh after the change. That seems to
be because, in at least some cases, a page or template that refers to the YAML
metadata elements may be scanned earlier than the page that contains the
edited YAML, causing the field plugin to find and use the old values from
%pagestate.

This patch addresses the problem by using the needsbuild hook, which precedes
scan, to empty $pagestate{$page}{ymlfront} for every page that will be
rebuilt.

Still unaddressed: needsbuild doesn't seem to be called for previews, so a
preview of a page that has YAML metadata, and displays some of it, will still
show the old values.
