### PR TITLE
Small YAML parser fixes

### DIFF
--- a/IkiWiki/Plugin/ymlfront.pm
+++ b/IkiWiki/Plugin/ymlfront.pm
@@ -2,6 +2,7 @@
 package IkiWiki::Plugin::ymlfront;
 use warnings;
 use strict;
+use Encode qw{encode};
 =head1 NAME
 
 IkiWiki::Plugin::ymlfront - add YAML-format data to a page
@@ -351,7 +352,7 @@ sub extract_yml {
 	$yml_str =~ s/\{\{\$page\}\}/$page/sg;
 
 	my $ydata;
-	eval {$ydata = Load($yml_str);};
+	eval {$ydata = Load(encode('UTF-8', $yml_str));};
 	if ($@)
 	{
 	    debug("ymlfront: Load of $page data failed: $@");
@@ -382,7 +383,7 @@ sub parse_yml {
 	$yml_str =~ s/\{\{\$page\}\}/$page/sg;
 
 	my $ydata;
-	eval {$ydata = Load($yml_str);};
+	eval {$ydata = Load(encode('UTF-8', $yml_str));};
 	if ($@)
 	{
 	    debug("ymlfront parse: Load of $page data failed: $@");

--- a/IkiWiki/Plugin/ymlfront.pm
+++ b/IkiWiki/Plugin/ymlfront.pm
@@ -83,8 +83,8 @@ sub getsetup () {
 }
 
 sub checkconfig () {
-    eval {use YAML::Any};
-    eval {use YAML} if $@;
+    eval {require YAML::Any; import YAML::Any;};
+    eval {require YAML; import YAML;} if $@;
     if ($@)
     {
 	return error ("ymlfront: failed to use YAML::Any or YAML");


### PR DESCRIPTION
`ymlfront` appears to be using `YAML` unconditionally, even when `YAML::Any` is available. This seems to be due to a quirk of the perl `use` statement.  I noticed this because comments in YAML blocks weren't handled properly: `YAML` apparently doesn't handle comments, whereas better parsers like `YAML::XS` do.

Also, non-ASCII characters don't work well, as perl's YAML parsers expect encoded UTF-8 and apparently we were giving them perl unicode strings instead.

These commits should fix these.