### PR TITLE
Add $escape to internal get_field_value call

### DIFF
--- a/IkiWiki/Plugin/getfield.pm
+++ b/IkiWiki/Plugin/getfield.pm
@@ -106,7 +106,7 @@ sub get_other_page_field_value ($$$) {
     # add a dependency for the page from which we get the value
     add_depends($page, $use_page);
 
-    my $val = get_field_value($field, $use_page);
+    my $val = get_field_value("", $field, $use_page);
     if ($val eq $field)
     {
 	return "${other_page}#$field";


### PR DESCRIPTION
get_other_page_field_value calls get_field_value, but the first parameter is now supposed to be an $escape string. The internal call was not including a value for this argument, so $field would get mapped to $escape and the remote field lookup fails.

This hack should be safe because we check the value of $escape at the beginning of the get_other_page_field_value (but I am no Perl programmer, so you should confirm this).
