### PR TITLE
Change internal function parameter lists

### DIFF
--- a/IkiWiki/Plugin/getfield.pm
+++ b/IkiWiki/Plugin/getfield.pm
@@ -92,7 +92,7 @@ sub do_filter (@) {
 #---------------------------------------------------------------
 # Private functions
 # --------------------------------
-sub get_other_page_field_value ($$$) {
+sub get_other_page_field_value ($$$$) {
     my $escape = shift;
     my $field = shift;
     my $page = shift;
@@ -115,7 +115,7 @@ sub get_other_page_field_value ($$$) {
 
 } # get_other_page_field_value
 
-sub get_field_value ($$) {
+sub get_field_value ($$$) {
     my $escape = shift;
     my $field = shift;
     my $page = shift;


### PR DESCRIPTION
It looks like get_field_value wants three parameters but there are only two "$" in the function declaration (and similarly for get_other_page_field_value). Is this correct? Perl does not like it when I call these functions from a different module unless I change the signatures. 

If you make this change I guess you should bump the version, but I am not including this in my pull request(s).
