### PR TITLE
Escape braces in regular expression

### DIFF
--- a/IkiWiki/Plugin/report.pm
+++ b/IkiWiki/Plugin/report.pm
@@ -95,7 +95,7 @@ sub preprocess (@) {
     my $this_page = $params{page};
     my $dest_page = $params{destpage};
     my $pages = (defined $params{pages} ? $params{pages} : '*');
-    $pages =~ s/{{\$page}}/$this_page/g;
+    $pages =~ s/\{\{\$page\}\}/$this_page/g;
 
     if (!defined $params{first_page_is_index})
     {


### PR DESCRIPTION
This removes the

    Unescaped left brace in regex is deprecated, passed through in regex

warning from Perl 5.22.

Fixes <https://github.com/rubykat/ikiplugins/issues/7>.